### PR TITLE
Add AsyncSemaphore and use in concurrentMap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Convert coverage files
       run: |
         xcrun llvm-cov export -format "lcov" \
-          .build/debug/hummingbirdPackageTests.xctest/Contents/MacOs/hummingbirdPackageTests \
+          .build/debug/async-collectionsPackageTests.xctest/Contents/MacOs/async-collectionsPackageTests \
           -ignore-filename-regex="\/Tests\/" \
           -ignore-filename-regex="\/Benchmarks\/" \
           -instr-profile=.build/debug/codecov/default.profdata > info.lcov
@@ -55,7 +55,7 @@ jobs:
     - name: Convert coverage files
       run: |
         llvm-cov export -format="lcov" \
-          .build/debug/hummingbirdPackageTests.xctest \
+          .build/debug/async-collectionsPackageTests.xctest \
           -ignore-filename-regex="\/Tests\/" \
           -ignore-filename-regex="\/Benchmarks\/" \
           -instr-profile .build/debug/codecov/default.profdata > info.lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - '**.swift'
+    - '**.yml'
+  pull_request:
+    branches:
+    - main
+    paths:
+    - '**.swift'
+    - '**.yml'
+  workflow_dispatch:
+
+jobs:
+  macOS:
+    runs-on: macOS-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: SPM tests
+      run: swift test --enable-code-coverage
+    - name: Convert coverage files
+      run: |
+        xcrun llvm-cov export -format "lcov" \
+          .build/debug/hummingbirdPackageTests.xctest/Contents/MacOs/hummingbirdPackageTests \
+          -ignore-filename-regex="\/Tests\/" \
+          -ignore-filename-regex="\/Benchmarks\/" \
+          -instr-profile=.build/debug/codecov/default.profdata > info.lcov
+    - name: Upload to codecov.io
+      uses: codecov/codecov-action@v3
+      with:
+        file: info.lcov
+  linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image:
+          - 'swift:5.5'
+          - 'swift:5.6'
+          - 'swift:5.7'
+    
+    container:
+      image: ${{ matrix.image }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Test
+      run: |
+        swift test --enable-code-coverage
+    - name: Convert coverage files
+      run: |
+        llvm-cov export -format="lcov" \
+          .build/debug/hummingbirdPackageTests.xctest \
+          -ignore-filename-regex="\/Tests\/" \
+          -ignore-filename-regex="\/Benchmarks\/" \
+          -instr-profile .build/debug/codecov/default.profdata > info.lcov
+    - name: Upload to codecov.io
+      uses: codecov/codecov-action@v3
+      with:
+        file: info.lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
           - 'swift:5.5'
           - 'swift:5.6'
           - 'swift:5.7'
+          - 'swiftlang/swift:nightly-5.8-jammy'
     
     container:
       image: ${{ matrix.image }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
     strategy:
       matrix:
         image:
+          - 'swift:5.5'
           - 'swift:5.6'
           - 'swift:5.7'
           - 'swiftlang/swift:nightly-5.8-jammy'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,6 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'swift:5.5'
           - 'swift:5.6'
           - 'swift:5.7'
           - 'swiftlang/swift:nightly-5.8-jammy'

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,24 @@
+# Minimum swiftformat version
+--minversion 0.47.4
+
+# Swift version
+--swiftversion 5.1
+
+# file options
+--exclude .build
+--exclude Sources/Soto/Services
+
+# rules
+--disable redundantReturn, redundantBackticks, trailingCommas, extensionAccessControl
+
+# format options
+--ifdef no-indent
+--nospaceoperators ...,..<
+--patternlet inline
+--self insert
+--stripunusedargs unnamed-only
+
+#--maxwidth 150
+--wraparguments before-first
+--wrapparameters before-first
+--wrapcollections before-first

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.5
+// swift-tools-version: 5.6
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -11,9 +11,11 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.0"),
     ],
     targets: [
         .target(name: "AsyncCollections", dependencies: [
+            .product(name: "Atomics", package: "swift-atomics"),
             .product(name: "Collections", package: "swift-collections"),
         ]),
         .testTarget(name: "AsyncCollectionTests", dependencies: ["AsyncCollections"]),

--- a/Package.swift
+++ b/Package.swift
@@ -5,12 +5,12 @@ import PackageDescription
 
 let package = Package(
     name: "async-collections",
-    platforms: [.macOS(.v12), .iOS(.v15), .tvOS(.v15), .watchOS(.v8)],
+    platforms: [.macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6)],
     products: [
         .library(name: "AsyncCollections", targets: ["AsyncCollections"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-collections", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
     ],
     targets: [
         .target(name: "AsyncCollections", dependencies: [

--- a/README.md
+++ b/README.md
@@ -18,8 +18,14 @@ try await array.concurrentForEach {
     try await asyncProcess($0)
 }
 ```
+You can manage the number of tasks running at any one time with the `maxConcurrentTasks` parameter
+```swift
+try await array.concurrentForEach(maxConcurrentTasks: 4) {
+    try await asyncProcess($0)
+}
+```
 
-## Map
+## AsyncMap
 
 Return an array transformed by an async function. 
 ```swift
@@ -27,17 +33,13 @@ let result = await array.asyncMap {
     return await asyncTransform($0)
 }
 ```
-Similar to `asyncForEach` there is a `concurrentMap` as well which will run the closures concurrently.
 
-## TaskQueue
-
-Use a `TaskQueue` to manage the number of concurrent tasks when processing a large sequence. 
+Similar to `asyncForEach` there are versions of `asyncMap` that runs the transforms concurrently.
 
 ```swift
-let queue = TaskQueue<Int>(maxConcurrentTasks: 8)
-let result = try await array.concurrentMap { value -> Int in
-    try await queue.add {
-        return await asyncTransform(value)
-    }
+let result = await array.concurrentMap(maxConcurrentTasks: 8) {
+    return await asyncTransform($0)
 }
 ```
+
+

--- a/Sources/AsyncCollections/AsyncSemaphore.swift
+++ b/Sources/AsyncCollections/AsyncSemaphore.swift
@@ -1,0 +1,109 @@
+import Collections
+import Foundation
+
+/// A Semaphore implementation that can be used with Swift Concurrency.
+///
+/// Waiting on this semaphore will not stall the underlying thread
+///
+/// Much of this is inspired by the implementation from Gwendal Roué found
+/// here https://github.com/groue/Semaphore. It manages to avoid the recursive
+/// lock by decrementing the semaphore counter inside the withTaskCancellationHandler
+/// function.
+public final class AsyncSemaphore: @unchecked Sendable {
+    struct Suspension: Sendable {
+        let continuation: UnsafeContinuation<Void, Error>
+        let id: UUID
+
+        init(_ continuation: UnsafeContinuation<Void, Error>, id: UUID) {
+            self.continuation = continuation
+            self.id = id
+        }
+    }
+
+    /// Semaphore value
+    private var value: Int
+    /// queue of suspensions waiting on semaphore
+    private var suspended: Deque<Suspension>
+    /// lock. Can only access `suspended` and `missedSignals` inside lock
+    private let _lock: NSLock
+
+    /// Initialize AsyncSemaphore
+    public init(value: Int = 0) {
+        self.value = .init(value)
+        self.suspended = []
+        self._lock = .init()
+    }
+
+    // Lock functionality has been moved to its own functions to avoid warning about using
+    // lock in an asynchronous context
+    func lock() { self._lock.lock() }
+    func unlock() { self._lock.unlock() }
+
+    /// Signal (increments) semaphore
+    /// - Returns: Returns if a task was awaken
+    @discardableResult public func signal() -> Bool {
+        self.lock()
+        self.value += 1
+        if self.value <= 0 {
+            // if value after signal is <= 0 then there should be a suspended
+            // task in the suspended array.
+            if let suspension = suspended.popFirst() {
+                self.unlock()
+                suspension.continuation.resume()
+            } else {
+                self.unlock()
+                fatalError("Cannot have a negative semaphore value without values in the suspension array")
+            }
+            return true
+        } else {
+            self.unlock()
+        }
+        return false
+    }
+
+    ///  Wait for or decrement a semaphore
+    public func wait() async throws {
+        let id = UUID()
+        try await withTaskCancellationHandler {
+            self.lock()
+            self.value -= 1
+            if self.value >= 0 {
+                self.unlock()
+                return
+            }
+            try await withUnsafeThrowingContinuation { (cont: UnsafeContinuation<Void, Error>) in
+                if Task.isCancelled {
+                    self.value += 1
+                    self.unlock()
+                    // if the state is cancelled, send cancellation error to continuation
+                    cont.resume(throwing: CancellationError())
+                } else {
+                    // set state to suspended and add to suspended array
+                    self.suspended.append(.init(cont, id: id))
+                    self.unlock()
+                }
+            }
+        } onCancel: {
+            self.lock()
+            if let index = self.suspended.firstIndex(where: { $0.id == id }) {
+                // if we find the suspension in the suspended array the remove and resume
+                // continuation with a cancellation error
+                self.value += 1
+                let suspension = self.suspended.remove(at: index)
+                self.unlock()
+                suspension.continuation.resume(throwing: CancellationError())
+            } else {
+                self.unlock()
+            }
+        }
+    }
+}
+
+extension AsyncSemaphore {
+    // used in tests
+    func getValue() -> Int {
+        return self._lock.withLock {
+            self.value
+        }
+    }
+}

--- a/Sources/AsyncCollections/ForEach.swift
+++ b/Sources/AsyncCollections/ForEach.swift
@@ -42,7 +42,7 @@ extension Sequence where Element: Sendable {
     public func concurrentForEach(maxConcurrentTasks: Int, priority: TaskPriority? = nil, _ body: @Sendable @escaping (Element) async throws -> Void) async rethrows {
         try await withThrowingTaskGroup(of: Void.self) { group in
             let semaphore = AsyncSemaphore(value: maxConcurrentTasks)
-            self.forEach { element in
+            for element in self {
                 try await semaphore.wait()
                 group.addTask(priority: priority) {
                     try await body(element)

--- a/Sources/AsyncCollections/Map.swift
+++ b/Sources/AsyncCollections/Map.swift
@@ -58,7 +58,57 @@ extension Sequence where Element: Sendable {
             return result
         }
         // construct final array and fill in elements
-        return Array<T>(unsafeUninitializedCapacity: result.count) { buffer, count in
+        return [T](unsafeUninitializedCapacity: result.count) { buffer, count in
+            for value in result {
+                (buffer.baseAddress! + value.0).initialize(to: value.1)
+            }
+            count = result.count
+        }
+    }
+
+    /// Returns an array containing the results of mapping the given async closure over
+    /// the sequence’s elements.
+    ///
+    /// This differs from `asyncMap` in that it uses a `TaskGroup` to run the transform
+    /// closure for all the elements of the Sequence. This allows all the transform closures
+    /// to run concurrently instead of serially. Returns only when the closure has been run
+    /// on all the elements of the Sequence.
+    /// - Parameters:
+    ///   - maxConcurrentTasks: Maximum number of tasks to running at the same time
+    ///   - priority: Task priority for tasks in TaskGroup
+    ///   - transform: An async  mapping closure. transform accepts an
+    ///     element of this sequence as its parameter and returns a transformed value of
+    ///     the same or of a different type.
+    /// - Returns: An array containing the transformed elements of this sequence.
+    public func concurrentMap<T: Sendable>(maxConcurrentTasks: Int, priority: TaskPriority? = nil, _ transform: @Sendable @escaping (Element) async throws -> T) async rethrows -> [T] {
+        let result: ContiguousArray<(Int, T)> = try await withThrowingTaskGroup(of: (Int, T).self) { group in
+            let semaphore = AsyncSemaphore(value: maxConcurrentTasks)
+            for element in self.enumerated() {
+                try await semaphore.wait()
+                group.addTask(priority: priority) {
+                    let result = try await transform(element.1)
+                    semaphore.signal()
+                    return (element.0, result)
+                }
+            }
+
+            // Code for collating results copied from Sequence.map in Swift codebase
+            let initialCapacity = underestimatedCount
+            var result = ContiguousArray<(Int, T)>()
+            result.reserveCapacity(initialCapacity)
+
+            // Add elements up to the initial capacity without checking for regrowth.
+            for _ in 0..<initialCapacity {
+                try await result.append(group.next()!)
+            }
+            // Add remaining elements, if any.
+            while let element = try await group.next() {
+                result.append(element)
+            }
+            return result
+        }
+        // construct final array and fill in elements
+        return [T](unsafeUninitializedCapacity: result.count) { buffer, count in
             for value in result {
                 (buffer.baseAddress! + value.0).initialize(to: value.1)
             }

--- a/Sources/AsyncCollections/TaskQueue.swift
+++ b/Sources/AsyncCollections/TaskQueue.swift
@@ -14,6 +14,7 @@ import Collections
 ///     }
 /// }
 /// ```
+@available(*, deprecated, message: "Use concurrentMap(maxConcurrentTasks:priority:transform:)")
 public actor TaskQueue<Result> {
     /// Task closure
     public typealias TaskFunc = @Sendable () async throws -> Result
@@ -24,6 +25,7 @@ public actor TaskQueue<Result> {
         let body: TaskFunc
         let continuation: UnsafeContinuation<Result, Error>
     }
+
     /// task queue
     var queue: Deque<TaskDetails>
     /// number of tasks in progress
@@ -77,7 +79,7 @@ public actor TaskQueue<Result> {
         // once task is complete if there are tasks on the queue then
         // initiate next task from queue.
         if let t = queue.popFirst(), !Task.isCancelled {
-            Task(priority: priority) {
+            Task(priority: self.priority) {
                 await self.performTask(t)
             }
         } else {

--- a/Tests/AsyncCollectionTests/AsyncSemaphoreTests.swift
+++ b/Tests/AsyncCollectionTests/AsyncSemaphoreTests.swift
@@ -1,0 +1,127 @@
+@testable import AsyncCollections
+import XCTest
+
+final class AsyncSemaphoreTests: XCTestCase {
+    func testSignalWait() async throws {
+        let semaphore = AsyncSemaphore()
+        let rt = semaphore.signal()
+        XCTAssertEqual(rt, false)
+        try await semaphore.wait()
+    }
+
+    func testNoWaitingTask() async throws {
+        let semaphore = AsyncSemaphore(value: 1)
+        let rt = semaphore.signal()
+        XCTAssertEqual(rt, false)
+        let rt2 = semaphore.signal()
+        XCTAssertEqual(rt2, false)
+        try await semaphore.wait()
+    }
+
+    func testWaitSignal() async throws {
+        await withThrowingTaskGroup(of: Void.self) { group in
+            let semaphore = AsyncSemaphore()
+            group.addTask {
+                try await semaphore.wait()
+            }
+            group.addTask {
+                semaphore.signal()
+            }
+        }
+    }
+
+    func testWaitDelayedSignal() async throws {
+        await withThrowingTaskGroup(of: Void.self) { group in
+            let semaphore = AsyncSemaphore()
+            group.addTask {
+                try await semaphore.wait()
+            }
+            group.addTask {
+                try await Task.sleep(nanoseconds: 100_000)
+                let rt = semaphore.signal()
+                XCTAssertEqual(rt, true)
+            }
+        }
+    }
+
+    func testDoubleWaitSignal() async throws {
+        await withThrowingTaskGroup(of: Void.self) { group in
+            let semaphore = AsyncSemaphore()
+            group.addTask {
+                try await semaphore.wait()
+            }
+            group.addTask {
+                try await semaphore.wait()
+            }
+            group.addTask {
+                try await Task.sleep(nanoseconds: 100_000)
+                let rt = semaphore.signal()
+                XCTAssertEqual(rt, true)
+                let rt2 = semaphore.signal()
+                XCTAssertEqual(rt2, true)
+            }
+        }
+    }
+
+    func testManySignalWait() async throws {
+        await withThrowingTaskGroup(of: Void.self) { group in
+            let semaphore = AsyncSemaphore()
+            group.addTask {
+                semaphore.signal()
+                try await semaphore.wait()
+                semaphore.signal()
+                try await semaphore.wait()
+                semaphore.signal()
+                try await semaphore.wait()
+            }
+            group.addTask {
+                semaphore.signal()
+                semaphore.signal()
+                semaphore.signal()
+                try await semaphore.wait()
+                try await semaphore.wait()
+                try await semaphore.wait()
+            }
+            group.addTask {
+                semaphore.signal()
+                semaphore.signal()
+                try await semaphore.wait()
+                try await semaphore.wait()
+                semaphore.signal()
+                try await semaphore.wait()
+            }
+        }
+    }
+
+    func testCancellationWhileSuspended() async throws {
+        let semaphore = AsyncSemaphore()
+        let task = Task {
+            do {
+                try await semaphore.wait()
+            } catch is CancellationError {
+                XCTAssertEqual(semaphore.getValue(), 0)
+            } catch {
+                XCTFail("Wrong Error")
+            }
+        }
+        try await Task.sleep(nanoseconds: 10000)
+        task.cancel()
+    }
+
+    func testCancellationBeforeWait() async throws {
+        let semaphore = AsyncSemaphore()
+        let task = Task {
+            do {
+                do {
+                    try await Task.sleep(nanoseconds: 100_000)
+                } catch {}
+                try await semaphore.wait()
+            } catch is CancellationError {
+                XCTAssertEqual(semaphore.getValue(), 0)
+            } catch {
+                XCTFail("Wrong Error")
+            }
+        }
+        task.cancel()
+    }
+}

--- a/Tests/AsyncCollectionTests/ForEachTests.swift
+++ b/Tests/AsyncCollectionTests/ForEachTests.swift
@@ -1,11 +1,11 @@
-import XCTest
 import AsyncCollections
+import XCTest
 
 final class ForEachTests: XCTestCase {
     func testAsyncForEach() async {
         let count = Count(1)
 
-        let primes = [2,3,5,7,11,13]
+        let primes = [2, 3, 5, 7, 11, 13]
         await primes.asyncForEach { await count.mul($0) }
 
         let value = await count.value
@@ -15,7 +15,7 @@ final class ForEachTests: XCTestCase {
     func testConcurrentForEach() async {
         let count = Count(1)
 
-        let primes = [2,3,5,7,11,13]
+        let primes = [2, 3, 5, 7, 11, 13]
         await primes.concurrentForEach { await count.mul($0) }
 
         let value = await count.value
@@ -26,10 +26,10 @@ final class ForEachTests: XCTestCase {
         let count = Count(0)
         let maxCount = Count(0)
 
-        try await (0..<8).asyncForEach { _ in
+        try await(0..<8).asyncForEach { _ in
             let value = await count.add(1)
             await maxCount.max(value)
-            try await Task.sleep(nanoseconds: UInt64.random(in: 1000..<1000*1000))
+            try await Task.sleep(nanoseconds: UInt64.random(in: 1000..<1000 * 1000))
             await count.add(-1)
         }
 
@@ -37,14 +37,14 @@ final class ForEachTests: XCTestCase {
         XCTAssertEqual(maxValue, 1)
     }
 
-    func testConcurrentConcurrentForEach() async throws {
+    func testConcurrentForEachConcurrency() async throws {
         let count = Count(0)
         let maxCount = Count(0)
 
-        try await (0..<8).concurrentForEach { _ in
+        try await(0..<8).concurrentForEach { _ in
             let value = await count.add(1)
             await maxCount.max(value)
-            try await Task.sleep(nanoseconds: UInt64.random(in: 1000..<1000*1000))
+            try await Task.sleep(nanoseconds: UInt64.random(in: 1000..<1000 * 1000))
             await count.add(-1)
         }
 
@@ -52,13 +52,29 @@ final class ForEachTests: XCTestCase {
         XCTAssertGreaterThan(maxValue, 1)
     }
 
+    func testConcurrentForEachConcurrencyWithMaxTasks() async throws {
+        let count = Count(0)
+        let maxCount = Count(0)
+
+        try await(0..<80).concurrentForEach(maxConcurrentTasks: 8) { _ in
+            let value = await count.add(1)
+            await maxCount.max(value)
+            try await Task.sleep(nanoseconds: UInt64.random(in: 1000..<1000 * 1000))
+            await count.add(-1)
+        }
+
+        let maxValue = await maxCount.value
+        XCTAssertGreaterThan(maxValue, 1)
+        XCTAssertLessThanOrEqual(maxValue, 8)
+    }
+
     func testAsyncForEachIrregularDuration() async throws {
         let count = Count(1)
 
-        let primes = [2,3,5,7,11,13]
+        let primes = [2, 3, 5, 7, 11, 13]
         try await primes.asyncForEach {
             await count.mul($0)
-            try await Task.sleep(nanoseconds: UInt64.random(in: 1000..<1000*1000))
+            try await Task.sleep(nanoseconds: UInt64.random(in: 1000..<1000 * 1000))
         }
 
         let value = await count.value
@@ -68,10 +84,10 @@ final class ForEachTests: XCTestCase {
     func testConcurrentForEachIrregularDuration() async throws {
         let count = Count(1)
 
-        let primes = [2,3,5,7,11,13]
+        let primes = [2, 3, 5, 7, 11, 13]
         try await primes.concurrentForEach {
             await count.mul($0)
-            try await Task.sleep(nanoseconds: UInt64.random(in: 1000..<1000*1000))
+            try await Task.sleep(nanoseconds: UInt64.random(in: 1000..<1000 * 1000))
         }
 
         let value = await count.value
@@ -83,7 +99,7 @@ final class ForEachTests: XCTestCase {
         let count = Count(1)
 
         do {
-            try await (1...8).asyncForEach {
+            try await(1...8).asyncForEach {
                 await count.mul($0)
                 if $0 == 4 {
                     throw TaskError()
@@ -92,7 +108,7 @@ final class ForEachTests: XCTestCase {
             XCTFail("Should have failed")
         } catch is TaskError {
             let value = await count.value
-            XCTAssertNotEqual(value, 1*2*3*4*5*6*7*8)
+            XCTAssertNotEqual(value, 1 * 2 * 3 * 4 * 5 * 6 * 7 * 8)
         } catch {
             XCTFail("Error: \(error)")
         }
@@ -103,7 +119,7 @@ final class ForEachTests: XCTestCase {
         let count = Count(1)
 
         let task = Task {
-            try await (0..<8).concurrentForEach {
+            try await(0..<8).concurrentForEach {
                 await count.mul($0)
                 if $0 == 4 {
                     throw TaskError()
@@ -135,7 +151,7 @@ final class ForEachTests: XCTestCase {
         task.cancel()
 
         let value = await count.value
-        XCTAssertNotEqual(value, 1*2*3*4*5*6*7*8)
+        XCTAssertNotEqual(value, 1 * 2 * 3 * 4 * 5 * 6 * 7 * 8)
     }
 
     func testConcurrentForEachCancellation() async throws {
@@ -152,7 +168,7 @@ final class ForEachTests: XCTestCase {
         task.cancel()
 
         let value = await count.value
-        XCTAssertNotEqual(value, 1*2*3*4*5*6*7*8)
+        XCTAssertNotEqual(value, 1 * 2 * 3 * 4 * 5 * 6 * 7 * 8)
     }
 }
 

--- a/Tests/AsyncCollectionTests/MapTests.swift
+++ b/Tests/AsyncCollectionTests/MapTests.swift
@@ -1,11 +1,11 @@
-import XCTest
 import AsyncCollections
+import XCTest
 
 final class MapTests: XCTestCase {
     func testAsyncMap() async throws {
-        let array = Array((0..<80))
+        let array = Array(0..<80)
         let result = try await array.asyncMap { value -> Int in
-            try await Task.sleep(nanoseconds: UInt64.random(in: 1000..<100000))
+            try await Task.sleep(nanoseconds: UInt64.random(in: 1000..<100_000))
             return value
         }
 
@@ -13,9 +13,9 @@ final class MapTests: XCTestCase {
     }
 
     func testConcurrentMap() async throws {
-        let array = Array((0..<800))
+        let array = Array(0..<800)
         let result = try await array.concurrentMap { value -> Int in
-            try await Task.sleep(nanoseconds: UInt64.random(in: 1000..<100000))
+            try await Task.sleep(nanoseconds: UInt64.random(in: 1000..<100_000))
             return value
         }
 
@@ -23,24 +23,24 @@ final class MapTests: XCTestCase {
     }
 
     func testConcurrentMapWithString() async throws {
-        let array = Array((0..<800))
+        let array = Array(0..<800)
         let result = try await array.concurrentMap { value -> String in
-            try await Task.sleep(nanoseconds: UInt64.random(in: 1000..<100000))
+            try await Task.sleep(nanoseconds: UInt64.random(in: 1000..<100_000))
             return String(value)
         }
 
         XCTAssertEqual(result, array.map { String($0) })
     }
 
-    func testConcurrentAsyncMap() async throws {
+    func testAsyncMapConcurrency() async throws {
         let count = Count(0)
         let maxCount = Count(0)
 
-        let array = Array((0..<80))
+        let array = Array(0..<80)
         let result = try await array.asyncMap { value -> Int in
             let c = await count.add(1)
             await maxCount.max(c)
-            try await Task.sleep(nanoseconds: UInt64.random(in: 1000..<100000))
+            try await Task.sleep(nanoseconds: UInt64.random(in: 1000..<100_000))
             await count.add(-1)
             return value
         }
@@ -50,15 +50,15 @@ final class MapTests: XCTestCase {
         XCTAssertEqual(maxValue, 1)
     }
 
-    func testConcurrentConcurrentMap() async throws {
+    func testConcurrentMapConcurrency() async throws {
         let count = Count(0)
         let maxCount = Count(0)
 
-        let array = Array((0..<800))
+        let array = Array(0..<800)
         let result = try await array.concurrentMap { value -> Int in
             let c = await count.add(1)
             await maxCount.max(c)
-            try await Task.sleep(nanoseconds: UInt64.random(in: 1000..<100000))
+            try await Task.sleep(nanoseconds: UInt64.random(in: 1000..<100_000))
             await count.add(-1)
             return value
         }
@@ -68,11 +68,30 @@ final class MapTests: XCTestCase {
         XCTAssertGreaterThan(maxValue, 1)
     }
 
+    func testConcurrentMapConcurrencyWithMaxTasks() async throws {
+        let count = Count(0)
+        let maxCount = Count(0)
+
+        let array = Array(0..<800)
+        let result = try await array.concurrentMap(maxConcurrentTasks: 4) { value -> Int in
+            let c = await count.add(1)
+            await maxCount.max(c)
+            try await Task.sleep(nanoseconds: UInt64.random(in: 1000..<100_000))
+            await count.add(-1)
+            return value
+        }
+
+        XCTAssertEqual(result, array)
+        let maxValue = await maxCount.value
+        XCTAssertLessThanOrEqual(maxValue, 4)
+        XCTAssertGreaterThan(maxValue, 1)
+    }
+
     func testAsyncMapErrorThrowing() async throws {
         struct TaskError: Error {}
 
         do {
-            _ = try await (1...8).asyncMap { element -> Int in
+            _ = try await(1...8).asyncMap { element -> Int in
                 if element == 4 {
                     throw TaskError()
                 }
@@ -89,7 +108,7 @@ final class MapTests: XCTestCase {
         struct TaskError: Error {}
 
         do {
-            _ = try await (1...8).concurrentMap { element -> Int in
+            _ = try await(1...8).concurrentMap { element -> Int in
                 if element == 4 {
                     throw TaskError()
                 }
@@ -116,7 +135,7 @@ final class MapTests: XCTestCase {
         try await Task.sleep(nanoseconds: 15 * 1000 * 100)
         task.cancel()
         let value = await count.value
-        XCTAssertNotEqual(value, 1*2*3*4*5*6*7*8)
+        XCTAssertNotEqual(value, 1 * 2 * 3 * 4 * 5 * 6 * 7 * 8)
     }
 
     func testConcurrentMapCancellation() async throws {
@@ -133,6 +152,6 @@ final class MapTests: XCTestCase {
         try await Task.sleep(nanoseconds: 1 * 1000 * 100)
         task.cancel()
         let value = await count.value
-        XCTAssertNotEqual(value, 1*2*3*4*5*6*7*8)
+        XCTAssertNotEqual(value, 1 * 2 * 3 * 4 * 5 * 6 * 7 * 8)
     }
 }


### PR DESCRIPTION
Add AsyncSemaphore and use in version of concurrentMap that limits the maximum number of concurrent tasks running at any one point. This replaces the TaskQueue. It is preferable to TaskQueue as it does not use unstructured Tasks