### PR TITLE
Add filter async methods, move to Swift 5.7, and some refinements for current funcs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: macOS-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: SPM tests
       run: swift test --enable-code-coverage
     - name: Convert coverage files
@@ -39,16 +39,16 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'swift:5.5'
-          - 'swift:5.6'
-          - 'swift:5.7'
-          - 'swiftlang/swift:nightly-5.8-jammy'
-    
-    container:
-      image: ${{ matrix.image }}
+          - swift:5.7-jammy
+          - swift:5.8-jammy
+          - swift:5.9-jammy
+          - swiftlang/swift:nightly-5.10-jammy
+          - swiftlang/swift:nightly-main-jammy
+
+    container: ${{ matrix.image }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Test
       run: |
         swift test --enable-code-coverage

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.5
+// swift-tools-version: 5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -1,0 +1,35 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let swiftSettings: [SwiftSetting] = [
+    .enableExperimentalFeature("StrictConcurrency=complete")
+]
+
+let package = Package(
+    name: "async-collections",
+    platforms: [.macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6)],
+    products: [
+        .library(name: "AsyncCollections", targets: ["AsyncCollections"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.0"),
+    ],
+    targets: [
+        .target(
+            name: "AsyncCollections",
+            dependencies: [
+                .product(name: "Atomics", package: "swift-atomics"),
+                .product(name: "Collections", package: "swift-collections"),
+            ],
+            swiftSettings: swiftSettings
+        ),
+        .testTarget(
+            name: "AsyncCollectionTests",
+            dependencies: ["AsyncCollections"],
+            swiftSettings: swiftSettings
+        ),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -42,4 +42,19 @@ let result = await array.concurrentMap(maxConcurrentTasks: 8) {
 }
 ```
 
+## Filter
 
+Return a filtered array transformed by an async function. 
+```swift
+let result = await array.asyncFilter {
+    return await asyncTransform($0)
+}
+```
+
+Similar to `asyncForEach` there are versions of `asyncFilter` that runs the transforms concurrently.
+
+```swift
+let result = await array.concurrentFilter(maxConcurrentTasks: 8) {
+    return await asyncTransform($0)
+}
+```

--- a/Sources/AsyncCollections/Filter.swift
+++ b/Sources/AsyncCollections/Filter.swift
@@ -62,7 +62,6 @@ extension Sequence where Element: Sendable {
         return result.sorted(by: { $0.0 < $1.0 }).map(\.1)
     }
 
-    /// Returns an array containing the results of mapping the given async closure over
     /// Returns an array containing, in order, the elements of the sequence
     /// that satisfy the given predicate.
     ///

--- a/Sources/AsyncCollections/Filter.swift
+++ b/Sources/AsyncCollections/Filter.swift
@@ -48,17 +48,9 @@ extension Sequence where Element: Sendable {
                 }
             }
             // Code for collating results copied from Sequence.map in Swift codebase
-            let initialCapacity = underestimatedCount
             var result = ContiguousArray<(Int, Element)>()
-            result.reserveCapacity(initialCapacity)
 
-            // Add elements up to the initial capacity without checking for regrowth.
-            for _ in 0..<initialCapacity {
-                if let enumerated = try await group.next()! {
-                    result.append(enumerated)
-                }
-            }
-            // Add remaining elements, if any.
+            // Add all the elements.
             while let next = try await group.next() {
                 if let enumerated = next {
                     result.append(enumerated)
@@ -89,10 +81,7 @@ extension Sequence where Element: Sendable {
         let result: ContiguousArray<(Int, Element)> = try await withThrowingTaskGroup(
             of: (Int, Element)?.self
         ) { group in
-            // Code for collating results copied from Sequence.map in Swift codebase
-            let initialCapacity = underestimatedCount
             var result = ContiguousArray<(Int, Element)>()
-            result.reserveCapacity(initialCapacity)
 
             for (index, element) in self.enumerated() {
                 if index >= maxConcurrentTasks {

--- a/Sources/AsyncCollections/Filter.swift
+++ b/Sources/AsyncCollections/Filter.swift
@@ -1,0 +1,123 @@
+
+extension Sequence where Element: Sendable {
+    /// Returns an array containing, in order, the elements of the sequence
+    /// that satisfy the given predicate.
+    ///
+    /// - Parameter isIncluded: An async closure that takes an element of the
+    ///   sequence as its argument and returns a Boolean value indicating
+    ///   whether the element should be included in the returned array.
+    /// - Returns: An array of the elements that `isIncluded` allowed.
+    public func asyncFilter(_ isIncluded: @Sendable (Element) async throws -> Bool) async rethrows -> [Element] {
+        var result = ContiguousArray<Element>()
+
+        var iterator = self.makeIterator()
+
+        while let element = iterator.next() {
+            if try await isIncluded(element) {
+                result.append(element)
+            }
+        }
+
+        return Array(result)
+    }
+
+    /// Returns an array containing, in order, the elements of the sequence
+    /// that satisfy the given predicate.
+    ///
+    /// This differs from `asyncFilter` in that it uses a `TaskGroup` to run the transform
+    /// closure for all the elements of the Sequence. This allows all the transform closures
+    /// to run concurrently instead of serially. Returns only when the closure has been run
+    /// on all the elements of the Sequence.
+    /// - Parameters:
+    ///   - priority: Task priority for tasks in TaskGroup
+    ///   - isIncluded: An async closure that takes an element of the
+    ///   sequence as its argument and returns a Boolean value indicating
+    ///   whether the element should be included in the returned array.
+    /// - Returns: An array of the elements that `isIncluded` allowed.
+    public func concurrentFilter(priority: TaskPriority? = nil, _ isIncluded: @Sendable @escaping (Element) async throws -> Bool) async rethrows -> [Element] {
+        let result: ContiguousArray<(Int, Element)> = try await withThrowingTaskGroup(
+            of: (Int, Element)?.self
+        ) { group in
+            for (index, element) in self.enumerated() {
+                group.addTask(priority: priority) {
+                    if try await isIncluded(element) {
+                        return (index, element)
+                    } else {
+                        return nil
+                    }
+                }
+            }
+            // Code for collating results copied from Sequence.map in Swift codebase
+            let initialCapacity = underestimatedCount
+            var result = ContiguousArray<(Int, Element)>()
+            result.reserveCapacity(initialCapacity)
+
+            // Add elements up to the initial capacity without checking for regrowth.
+            for _ in 0..<initialCapacity {
+                if let enumerated = try await group.next()! {
+                    result.append(enumerated)
+                }
+            }
+            // Add remaining elements, if any.
+            while let next = try await group.next() {
+                if let enumerated = next {
+                    result.append(enumerated)
+                }
+            }
+            return result
+        }
+
+        return result.sorted(by: { $0.0 < $1.0 }).map(\.1)
+    }
+
+    /// Returns an array containing the results of mapping the given async closure over
+    /// Returns an array containing, in order, the elements of the sequence
+    /// that satisfy the given predicate.
+    ///
+    /// This differs from `asyncFilter` in that it uses a `TaskGroup` to run the transform
+    /// closure for all the elements of the Sequence. This allows all the transform closures
+    /// to run concurrently instead of serially. Returns only when the closure has been run
+    /// on all the elements of the Sequence.
+    /// - Parameters:
+    ///   - maxConcurrentTasks: Maximum number of tasks to running at the same time
+    ///   - priority: Task priority for tasks in TaskGroup
+    ///   - isIncluded: An async closure that takes an element of the
+    ///   sequence as its argument and returns a Boolean value indicating
+    ///   whether the element should be included in the returned array.
+    /// - Returns: An array of the elements that `isIncluded` allowed.
+    public func concurrentFilter(maxConcurrentTasks: Int, priority: TaskPriority? = nil, _ isIncluded: @Sendable @escaping (Element) async throws -> Bool) async rethrows -> [Element] {
+        let result: ContiguousArray<(Int, Element)> = try await withThrowingTaskGroup(
+            of: (Int, Element)?.self
+        ) { group in
+            // Code for collating results copied from Sequence.map in Swift codebase
+            let initialCapacity = underestimatedCount
+            var result = ContiguousArray<(Int, Element)>()
+            result.reserveCapacity(initialCapacity)
+
+            for (index, element) in self.enumerated() {
+                if index >= maxConcurrentTasks {
+                    if let enumerated = try await group.next() ?? nil {
+                        result.append(enumerated)
+                    }
+                }
+                group.addTask(priority: priority) {
+                    if try await isIncluded(element) {
+                        return (index, element)
+                    } else {
+                        return nil
+                    }
+                }
+            }
+
+            // Add remaining elements, if any.
+            while let next = try await group.next() {
+                if let enumerated = next {
+                    result.append(enumerated)
+                }
+            }
+            return result
+        }
+
+        return result.sorted(by: { $0.0 < $1.0 }).map(\.1)
+    }
+}

--- a/Sources/AsyncCollections/ForEach.swift
+++ b/Sources/AsyncCollections/ForEach.swift
@@ -6,7 +6,7 @@ extension Sequence where Element: Sendable {
     /// has finished. Returns once the closure has run on all the elements of the Sequence
     /// or when the closure throws an error
     /// - Parameter body: Closure to be called for each element
-    public func asyncForEach(_ body: @Sendable @escaping (Element) async throws -> Void) async rethrows {
+    public func asyncForEach(_ body: @Sendable (Element) async throws -> Void) async rethrows {
         for element in self {
             try await body(element)
         }

--- a/Sources/AsyncCollections/Map.swift
+++ b/Sources/AsyncCollections/Map.swift
@@ -10,7 +10,7 @@ extension Sequence where Element: Sendable {
     ///     element of this sequence as its parameter and returns a transformed value of
     ///     the same or of a different type.
     /// - Returns: An array containing the transformed elements of this sequence.
-    public func asyncMap<T: Sendable>(_ transform: @Sendable @escaping (Element) async throws -> T) async rethrows -> [T] {
+    public func asyncMap<T>(_ transform: @Sendable (Element) async throws -> T) async rethrows -> [T] {
         let initialCapacity = underestimatedCount
         var result = ContiguousArray<T>()
         result.reserveCapacity(initialCapacity)

--- a/Sources/AsyncCollections/Map.swift
+++ b/Sources/AsyncCollections/Map.swift
@@ -41,7 +41,7 @@ extension Sequence where Element: Sendable {
     ///     element of this sequence as its parameter and returns a transformed value of
     ///     the same or of a different type.
     /// - Returns: An array containing the transformed elements of this sequence.
-    public func concurrentMap<T>(priority: TaskPriority? = nil, _ transform: @Sendable @escaping (Element) async throws -> T) async rethrows -> [T] {
+    public func concurrentMap<T: Sendable>(priority: TaskPriority? = nil, _ transform: @Sendable @escaping (Element) async throws -> T) async rethrows -> [T] {
         let result: ContiguousArray<(Int, T)> = try await withThrowingTaskGroup(of: (Int, T).self) { group in
             for (index, element) in self.enumerated() {
                 group.addTask(priority: priority) {
@@ -87,7 +87,7 @@ extension Sequence where Element: Sendable {
     ///     element of this sequence as its parameter and returns a transformed value of
     ///     the same or of a different type.
     /// - Returns: An array containing the transformed elements of this sequence.
-    public func concurrentMap<T>(maxConcurrentTasks: Int, priority: TaskPriority? = nil, _ transform: @Sendable @escaping (Element) async throws -> T) async rethrows -> [T] {
+    public func concurrentMap<T: Sendable>(maxConcurrentTasks: Int, priority: TaskPriority? = nil, _ transform: @Sendable @escaping (Element) async throws -> T) async rethrows -> [T] {
         let result: ContiguousArray<(Int, T)> = try await withThrowingTaskGroup(of: (Int, T).self) { group in
             var results = ContiguousArray<(Int, T)>()
             for (index, element) in self.enumerated() {

--- a/Sources/AsyncCollections/TaskQueue.swift
+++ b/Sources/AsyncCollections/TaskQueue.swift
@@ -15,7 +15,7 @@ import Collections
 /// }
 /// ```
 @available(*, deprecated, message: "Use concurrentMap(maxConcurrentTasks:priority:transform:)")
-public actor TaskQueue<Result> {
+public actor TaskQueue<Result: Sendable> {
     /// Task closure
     public typealias TaskFunc = @Sendable () async throws -> Result
 

--- a/Tests/AsyncCollectionTests/FilterTests.swift
+++ b/Tests/AsyncCollectionTests/FilterTests.swift
@@ -1,0 +1,163 @@
+import AsyncCollections
+import XCTest
+
+final class FilterTests: XCTestCase {
+    func testAsyncFilter() async throws {
+        let array = Array(0..<80).map { (element: $0, isIncluded: Bool.random()) }
+        let result = try await array.asyncFilter { value -> Bool in
+            try await Task.sleep(nanoseconds: UInt64.random(in: 1000..<100_000))
+            return value.isIncluded
+        }
+
+        XCTAssertTrue(result.allSatisfy(\.isIncluded))
+        XCTAssertEqual(result.map(\.element), array.filter(\.isIncluded).map(\.element))
+    }
+
+    func testConcurrentFilter() async throws {
+        let array = Array(0..<80).map { (element: $0, isIncluded: Bool.random()) }
+        let result = try await array.concurrentFilter { value -> Bool in
+            try await Task.sleep(nanoseconds: UInt64.random(in: 1000..<100_000))
+            return value.isIncluded
+        }
+
+        XCTAssertTrue(result.allSatisfy(\.isIncluded))
+        XCTAssertEqual(result.map(\.element), array.filter(\.isIncluded).map(\.element))
+    }
+
+    func testConcurrentFilterWithString() async throws {
+        let array = Array(0..<80).map { (element: "\($0)", isIncluded: Bool.random()) }
+        let result = try await array.concurrentFilter { value -> Bool in
+            try await Task.sleep(nanoseconds: UInt64.random(in: 1000..<100_000))
+            return value.isIncluded
+        }
+
+        XCTAssertTrue(result.allSatisfy(\.isIncluded))
+        XCTAssertEqual(result.map(\.element), array.filter(\.isIncluded).map(\.element))
+    }
+
+    func testAsyncFilterConcurrency() async throws {
+        let count = Count(0)
+        let maxCount = Count(0)
+
+        let array = Array(0..<80).map { (element: "\($0)", isIncluded: Bool.random()) }
+        let result = try await array.asyncFilter { value -> Bool in
+            let c = await count.add(1)
+            await maxCount.max(c)
+            try await Task.sleep(nanoseconds: UInt64.random(in: 1000..<100_000))
+            await count.add(-1)
+            return value.isIncluded
+        }
+
+        XCTAssertTrue(result.allSatisfy(\.isIncluded))
+        XCTAssertEqual(result.map(\.element), array.filter(\.isIncluded).map(\.element))
+        let maxValue = await maxCount.value
+        XCTAssertEqual(maxValue, 1)
+    }
+
+    func testConcurrentFilterConcurrency() async throws {
+        let count = Count(0)
+        let maxCount = Count(0)
+
+        let array = Array(0..<80).map { (element: "\($0)", isIncluded: Bool.random()) }
+        let result = try await array.concurrentFilter { value -> Bool in
+            let c = await count.add(1)
+            await maxCount.max(c)
+            try await Task.sleep(nanoseconds: UInt64.random(in: 1000..<100_000))
+            await count.add(-1)
+            return value.isIncluded
+        }
+
+        XCTAssertTrue(result.allSatisfy(\.isIncluded))
+        XCTAssertEqual(result.map(\.element), array.filter(\.isIncluded).map(\.element))
+        let maxValue = await maxCount.value
+        XCTAssertGreaterThan(maxValue, 1)
+    }
+
+    func testConcurrentFilterConcurrencyWithMaxTasks() async throws {
+        let count = Count(0)
+        let maxCount = Count(0)
+
+        let array = Array(0..<80).map { (element: "\($0)", isIncluded: Bool.random()) }
+        let result = try await array.concurrentFilter(maxConcurrentTasks: 4) { value -> Bool in
+            let c = await count.add(1)
+            await maxCount.max(c)
+            try await Task.sleep(nanoseconds: UInt64.random(in: 1000..<100_000))
+            await count.add(-1)
+            return value.isIncluded
+        }
+
+        XCTAssertTrue(result.allSatisfy(\.isIncluded))
+        XCTAssertEqual(result.map(\.element), array.filter(\.isIncluded).map(\.element))
+        let maxValue = await maxCount.value
+        XCTAssertLessThanOrEqual(maxValue, 4)
+        XCTAssertGreaterThan(maxValue, 1)
+    }
+
+    func testAsyncFilterErrorThrowing() async throws {
+        struct TaskError: Error {}
+
+        do {
+            _ = try await(1...8).asyncFilter { element -> Bool in
+                if element == 4 {
+                    throw TaskError()
+                }
+                return Bool.random()
+            }
+            XCTFail("Should have failed")
+        } catch is TaskError {
+        } catch {
+            XCTFail("Error: \(error)")
+        }
+    }
+
+    func testConcurrentFilterErrorThrowing() async throws {
+        struct TaskError: Error {}
+
+        do {
+            _ = try await(1...8).concurrentFilter { element -> Bool in
+                if element == 4 {
+                    throw TaskError()
+                }
+                return Bool.random()
+            }
+            XCTFail("Should have failed")
+        } catch is TaskError {
+        } catch {
+            XCTFail("Error: \(error)")
+        }
+    }
+
+    func testAsyncFilterCancellation() async throws {
+        let count = Count(1)
+
+        let array = Array((1...8).reversed())
+        let task = Task {
+            _ = try await array.asyncFilter { value -> Bool in
+                try await Task.sleep(nanoseconds: numericCast(value) * 1000 * 100)
+                await count.mul(value)
+                return Bool.random()
+            }
+        }
+        try await Task.sleep(nanoseconds: 15 * 1000 * 100)
+        task.cancel()
+        let value = await count.value
+        XCTAssertNotEqual(value, 1 * 2 * 3 * 4 * 5 * 6 * 7 * 8)
+    }
+
+    func testConcurrentFilterCancellation() async throws {
+        let count = Count(1)
+
+        let array = Array((1...8).reversed())
+        let task = Task {
+            _ = try await array.concurrentFilter { value -> Bool in
+                try await Task.sleep(nanoseconds: numericCast(value) * 1000 * 100)
+                await count.mul(value)
+                return Bool.random()
+            }
+        }
+        try await Task.sleep(nanoseconds: 1 * 1000 * 100)
+        task.cancel()
+        let value = await count.value
+        XCTAssertNotEqual(value, 1 * 2 * 3 * 4 * 5 * 6 * 7 * 8)
+    }
+}


### PR DESCRIPTION
* Add filter methods accepting async closures
* Update README with the new filter methods
* Add tests for the new filter methods
* Some fixes for existing functions
* Move to Swift 5.7
* Enable `swift-concurrency=complete` on 5.9+
* Update CI

i could also remove the Filter method and add it to another PR, so there is 2 PRs, one with some general refinements and one with the new function(s), if you care.